### PR TITLE
[SCRIPT] serve.py: verbosity

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -27,15 +27,15 @@ handler.extensions_map.update({
 })
 
 socketserver.TCPServer.allow_reuse_address = True
+print("Serving at port", PORT)
+print("View at: http://localhost:{}/".format(PORT))
 # The context manager protocol is support only since python 3.6 and higher.
 if (3 <= sys.version_info[0]) and (6 <= sys.version_info[1]):
     with socketserver.TCPServer(("", PORT), handler) as httpd:
         httpd.allow_reuse_address = True
-        print("Serving at port", PORT)
         httpd.serve_forever()
 else:
     httpd = socketserver.TCPServer(("", PORT), handler)
     httpd.allow_reuse_address = True
-    print("Serving at port", PORT)
     httpd.serve_forever()
     httpd.serve_close()


### PR DESCRIPTION
Display the address of the URL used by the server. Easy the copy/paste.