### PR TITLE
delete cargo-watch version from Makefile.toml

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,7 +37,7 @@ dependencies = ["build", "create_wasm"]
 description = "Build, create wasms, and watch/recompile files for changes"
 workspace = false
 dependencies = ["build", "create_wasm"]
-watch = { ignore_pattern="pkg/*", version="7.2.1" }
+watch = { ignore_pattern="pkg/*" }
 
 [tasks.all_release]
 description = "Build, and create wasms, with the --release flag"


### PR DESCRIPTION
#7 - It works with the latest `cargo-make` version thanks to your PR ([cargo-make changelog](https://github.com/sagiegurari/cargo-make/blob/master/CHANGELOG.md)). So I think we should delete version in `seed-quickstart` because it's easy to forget update it in the future and `cargo-make` should use the latest `cargo-watch` or at least set a compatible one.